### PR TITLE
Add issues and pull requests templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,33 @@
+**I'm submitting a ...**
+
+- [ ] bug report
+- [ ] feature request
+- [ ] support request
+
+### Summary
+
+<!--- Provide a general summary of the issue -->
+
+### Expected Behavior
+
+<!--- Tell us what should happen -->
+
+### Actual Behavior
+
+<!--- Tell us what happens instead -->
+
+### URL, screenshot, or snippet exhibiting the issue
+
+### Steps to Reproduce
+
+1.
+2.
+3.
+
+### Your Environment
+
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+
+- Version:
+- Browser Name and version:
+- Operating System and version (desktop or mobile):

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+- [ ] Tests for the changes have been added (for bug fixes / features)
+- [ ] Docs have been added / updated (for bug fixes / features)
+
+#### What does this PR do?
+
+#### Where should the reviewer start?
+
+#### What testing has been done on this PR?
+
+#### What are the relevant issues?
+
+#### Screenshots (if appropriate)
+
+#### Is this change backwards compatible or is it a breaking change?


### PR DESCRIPTION
This PR includes templates to Issues and Pull Requests to this repository. 

Keep in mind those still need to be set up as templates on the repo settings.

Closes #1 