### PR TITLE
Feat/support multi auth

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,11 +3,14 @@ HUBOT_DISCORD_TOKEN=
 GMAIL_CLIENT_ID=
 GMAIL_CLIENT_SECRET=
 GMAIL_REDIRECT_URIS=
-GMAIL_ACCESS_TOKEN=
-GMAIL_REFRESH_TOKEN=
 GMAIL_SCOPE='https://www.googleapis.com/auth/calendar.readonly https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.modify https://www.googleapis.com/auth/youtube.readonly'
 GMAIL_TOKEN_TYPE=
 GMAIL_EXPIRY_DATE=
+
+GMAIL_ACCESS_TOKEN=
+GMAIL_REFRESH_TOKEN=
+YOUTUBE_ACCESS_TOKEN=
+YOUTUBE_REFRESH_TOKEN=
 
 CALENDAR_ID=
 CALENDAR_MAX_RESULTS=10

--- a/lib/config.js
+++ b/lib/config.js
@@ -5,8 +5,14 @@ module.exports = {
   CLIENT_SECRET: process.env.GMAIL_CLIENT_SECRET,
   REDIRECT_URIS: process.env.GMAIL_REDIRECT_URIS,
   token: {
-    access_token: process.env.GMAIL_ACCESS_TOKEN,
-    refresh_token: process.env.GMAIL_REFRESH_TOKEN,
+    gmail: {
+      access_token: process.env.GMAIL_ACCESS_TOKEN,
+      refresh_token: process.env.GMAIL_REFRESH_TOKEN
+    },
+    youtube: {
+      access_token: process.env.YOUTUBE_ACCESS_TOKEN,
+      refresh_token: process.env.YOUTUBE_REFRESH_TOKEN
+    },
     scope: process.env.GMAIL_SCOPE,
     token_type: process.env.GMAIL_TOKEN_TYPE,
     expiry_date: process.env.GMAIL_EXPIRY_DATE

--- a/lib/google/authenticate.js
+++ b/lib/google/authenticate.js
@@ -1,7 +1,7 @@
 const { CLIENT_ID, CLIENT_SECRET, token } = require('../config')
 const { google } = require('googleapis')
 
-const authenticate = () => {
+const authenticate = (platform = 'gmail') => {
   const oAuth2Client = new google.auth.OAuth2(
     {
       clientId: CLIENT_ID,
@@ -9,7 +9,10 @@ const authenticate = () => {
     }
   )
 
-  oAuth2Client.setCredentials(token)
+  // eslint-disable-next-line camelcase
+  const { token_type, scope, expiry_date } = token
+
+  oAuth2Client.setCredentials({ token_type, scope, expiry_date, ...token[platform] })
   return oAuth2Client
 }
 

--- a/lib/google/calendarEvents.js
+++ b/lib/google/calendarEvents.js
@@ -4,7 +4,7 @@ const { authenticate } = require('./authenticate')
 const { google } = require('googleapis')
 
 const getCalendarEvents = async () => {
-  const auth = authenticate()
+  const auth = authenticate('gmail')
   const calendar = google.calendar({
     version: 'v3',
     auth

--- a/lib/google/retrieveEmail.js
+++ b/lib/google/retrieveEmail.js
@@ -17,7 +17,7 @@ const markEmailAsRead = (gmailClient, threadId) => {
 }
 
 const getEmail = async ({ from }) => {
-  const auth = authenticate()
+  const auth = authenticate('gmail')
   const gmailClient = google.gmail({ version: 'v1', auth })
   const messageList = await gmailClient.users.messages.list({
     userId: 'me',

--- a/lib/google/youtube.js
+++ b/lib/google/youtube.js
@@ -3,7 +3,7 @@ const { authenticate } = require('./authenticate')
 const { google } = require('googleapis')
 
 const getStreams = async ({ max = 5, status = 'upcoming' } = {}) => {
-  const auth = authenticate()
+  const auth = authenticate('youtube')
   const youtube = google.youtube({ version: 'v3', auth })
 
   const streams = await youtube.liveBroadcasts.list({


### PR DESCRIPTION
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

#### What does this PR do?

Enables support for YouTube and Gmail authentication tokens so `!egghead` and `!youtube`.

#### Where should the reviewer start?

The `authenticate.js` file.

#### What testing has been done on this PR?

Locally, running the `!egghead` and `!youtube` commands.

#### What are the relevant issues?

An issue where you cannot run `!egghead` and `!youtube` with the same Gmail Auth Token.

#### Screenshots (if appropriate)

#### Is this change backwards compatible or is it a breaking change?

It's a breaking change. Messes with the config file.
