### PR TITLE
`!calendar`: Fix Google API call to correctly retrieve events information.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ You can start Marvin as a local server to connect to Discord.
 23. Go to google calendar, in the left tab, select your calendar or create one. To select, click in the vertical threed dots.
 24. In `Settings and sharing` you will find a `Calendar ID` in the bottom of the page. Fill the variable.
 
+### Including calendars on Google Calendar
+
+If you're running Marvin on your organization, by default it has access to Google Calendar. However, if you can't see or access calendars when running `!calendar`, go to the Google Calendar **Configuration Menu** > **Integrate Calendar** and add the respective Calendar ID. After that, you should see the events of the calendar on Marvin's account, and `!calendar` should work as intended. 
+
 ### Allow users to use the `!streamyard` command
 
 To allow an user to use the `!streamyard` command to login into streamyard.com,

--- a/lib/google/calendarEvents.js
+++ b/lib/google/calendarEvents.js
@@ -11,12 +11,12 @@ const getCalendarEvents = async () => {
   })
 
   const currentDay = DateTime.local().setZone('America/Sao_Paulo').toISO()
-  const endOfTheCurrentWeek = DateTime.local().setZone('America/Sao_Paulo').endOf('week').toISO()
+  const upcomingSevenDays = DateTime.local().setZone('America/Sao_Paulo').plus({ week: 1 }).toISO()
 
   const events = await calendar.events.list({
     calendarId: CALENDAR_ID,
     timeMin: currentDay,
-    timeMax: endOfTheCurrentWeek,
+    timeMax: upcomingSevenDays,
     singleEvents: true,
     showDeleted: true
   })

--- a/lib/google/calendarEvents.js
+++ b/lib/google/calendarEvents.js
@@ -10,11 +10,14 @@ const getCalendarEvents = async () => {
     auth
   })
 
-  var actualTimeString = DateTime.local().setZone('America/Sao_Paulo').toISO()
+  const currentDay = DateTime.local().setZone('America/Sao_Paulo').toISO()
+  const endOfTheCurrentWeek = DateTime.local().setZone('America/Sao_Paulo').endOf('week').toISO()
 
   const events = await calendar.events.list({
     calendarId: CALENDAR_ID,
-    timeMin: actualTimeString,
+    timeMin: currentDay,
+    timeMax: endOfTheCurrentWeek,
+    singleEvents: true,
     showDeleted: true
   })
 

--- a/lib/google/retrieveCalendar.js
+++ b/lib/google/retrieveCalendar.js
@@ -7,9 +7,8 @@ const getEventsList = async () => {
   return events
     .map(event => {
       const date = DateTime.fromISO(event.start.dateTime, { locale: 'pt-br', zone: 'America/Sao_Paulo' })
-      const now = DateTime.local()
 
-      if (date.toMillis() < now.toMillis() || event.status === 'cancelled') {
+      if (event.status === 'cancelled') {
         return null
       }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,4 @@
+const WEEK_DAYS = ['DOMINGO', 'SEGUNDA-FEIRA', 'TERÇA-FEIRA', 'QUARTA-FEIRA', 'QUINTA-FEIRA', 'SEXTA-FEIRA', 'SÁBADO']
 const URL_RE = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/g
 
 const isAllowedStreamYardUser = (userId) => {
@@ -7,4 +8,9 @@ const isAllowedStreamYardUser = (userId) => {
 
 const preventUrlExpansion = (message) => message.replace(URL_RE, '<$&>')
 
-module.exports = { isAllowedStreamYardUser, preventUrlExpansion }
+const getDayName = (dateTime) => {
+  const date = new Date(dateTime)
+  return WEEK_DAYS[date.getDay()]
+}
+
+module.exports = { isAllowedStreamYardUser, preventUrlExpansion, getDayName }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,3 @@
-const WEEK_DAYS = ['DOMINGO', 'SEGUNDA-FEIRA', 'TERÇA-FEIRA', 'QUARTA-FEIRA', 'QUINTA-FEIRA', 'SEXTA-FEIRA', 'SÁBADO']
 const URL_RE = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/g
 
 const isAllowedStreamYardUser = (userId) => {
@@ -8,9 +7,9 @@ const isAllowedStreamYardUser = (userId) => {
 
 const preventUrlExpansion = (message) => message.replace(URL_RE, '<$&>')
 
-const getDayName = (dateTime) => {
+const getDayName = (dateTime, locale = 'pt-br') => {
   const date = new Date(dateTime)
-  return WEEK_DAYS[date.getDay()]
+  return date.toLocaleDateString(locale, { weekday: 'long' }).toUpperCase()
 }
 
 module.exports = { isAllowedStreamYardUser, preventUrlExpansion, getDayName }

--- a/scripts/google.js
+++ b/scripts/google.js
@@ -12,7 +12,7 @@ const retrieveCalendar = require('../lib/google/retrieveCalendar')
 const youtube = require('../lib/google/youtube')
 const retrieveEmail = require('../lib/google/retrieveEmail')
 const { DateTime } = require('luxon')
-const { isAllowedStreamYardUser, preventUrlExpansion } = require('../lib/utils')
+const { isAllowedStreamYardUser, preventUrlExpansion, getDayName } = require('../lib/utils')
 
 module.exports = (robot) => {
   robot.hear(/!calendar\b/, res => {
@@ -22,6 +22,7 @@ module.exports = (robot) => {
         return events.map(event => {
           return [
             '',
+            `> ${getDayName(event.date)}`,
             `> **${event.title}**`,
             `> _${event.date.toLocaleString(DateTime.DATETIME_MED)}_`,
             event.description

--- a/scripts/google.js
+++ b/scripts/google.js
@@ -15,6 +15,8 @@ const { DateTime } = require('luxon')
 const { isAllowedStreamYardUser, preventUrlExpansion, getDayName } = require('../lib/utils')
 
 module.exports = (robot) => {
+  const locale = 'pt-br'
+
   robot.hear(/!calendar\b/, res => {
     retrieveCalendar
       .getEventsList()
@@ -22,7 +24,7 @@ module.exports = (robot) => {
         return events.map(event => {
           return [
             '',
-            `> ${getDayName(event.date, 'pt-br')}`,
+            `> ${getDayName(event.date, locale)}`,
             `> **${event.title}**`,
             `> _${event.date.toLocaleString(DateTime.DATETIME_MED)}_`,
             event.description
@@ -89,7 +91,7 @@ module.exports = (robot) => {
     youtube
       .getStreams({ max: 3, status: 'upcoming' })
       .then((streams) => streams.map((stream) => {
-        const date = DateTime.fromISO(stream.snippet.scheduledStartTime, { locale: 'pt-br', zone: 'America/Sao_Paulo' })
+        const date = DateTime.fromISO(stream.snippet.scheduledStartTime, { locale, zone: 'America/Sao_Paulo' })
         const dateStr = date.toLocaleString(DateTime.DATETIME_MED)
 
         return [
@@ -117,7 +119,7 @@ module.exports = (robot) => {
     youtube
       .getStreams({ max: 100, status: 'upcoming' })
       .then((streams) => streams.map((stream) => {
-        const date = DateTime.fromISO(stream.snippet.scheduledStartTime, { locale: 'pt-br', zone: 'America/Sao_Paulo' })
+        const date = DateTime.fromISO(stream.snippet.scheduledStartTime, { locale, zone: 'America/Sao_Paulo' })
         const dateStr = date.toLocaleString(DateTime.DATETIME_MED)
 
         return ` - _${dateStr}_, **${stream.snippet.title}**, <https://youtube.com/watch?v=${stream.id}>`
@@ -138,7 +140,7 @@ module.exports = (robot) => {
     youtube
       .getStreams({ max: 1, status: 'completed' })
       .then((streams) => streams.map((stream) => {
-        const date = DateTime.fromISO(stream.snippet.scheduledStartTime, { locale: 'pt-br', zone: 'America/Sao_Paulo' })
+        const date = DateTime.fromISO(stream.snippet.scheduledStartTime, { locale, zone: 'America/Sao_Paulo' })
         const dateStr = date.toLocaleString(DateTime.DATETIME_MED)
 
         return [
@@ -162,7 +164,7 @@ module.exports = (robot) => {
     youtube
       .getStreams({ max: 1, status: 'upcoming' })
       .then((streams) => streams.map((stream) => {
-        const date = DateTime.fromISO(stream.snippet.scheduledStartTime, { locale: 'pt-br', zone: 'America/Sao_Paulo' })
+        const date = DateTime.fromISO(stream.snippet.scheduledStartTime, { locale, zone: 'America/Sao_Paulo' })
         const dateStr = date.toLocaleString(DateTime.DATETIME_MED)
 
         return [

--- a/scripts/google.js
+++ b/scripts/google.js
@@ -22,7 +22,7 @@ module.exports = (robot) => {
         return events.map(event => {
           return [
             '',
-            `> ${getDayName(event.date)}`,
+            `> ${getDayName(event.date, 'pt-br')}`,
             `> **${event.title}**`,
             `> _${event.date.toLocaleString(DateTime.DATETIME_MED)}_`,
             event.description

--- a/test/lib/utils_test.js
+++ b/test/lib/utils_test.js
@@ -34,7 +34,7 @@ describe('/lib/utils', () => {
     })
   })
 
-  describe('.getDayName', () => {
+  describe.only('.getDayName', () => {
     it('returns an uppercase string', () => {
       const dateTime = DateTime.local()
       const subject = getDayName(dateTime)
@@ -49,6 +49,18 @@ describe('/lib/utils', () => {
       expect(getDayName(DateTime.local(2022, 3, 24))).to.eq('QUINTA-FEIRA')
       expect(getDayName(DateTime.local(2022, 3, 25))).to.eq('SEXTA-FEIRA')
       expect(getDayName(DateTime.local(2022, 3, 26))).to.eq('SÁBADO')
+    })
+
+    context('when given a locale', () => {
+      it('returns the translated day of the week', () => {
+        expect(getDayName(DateTime.local(2022, 3, 20), 'en')).to.eq('SUNDAY')
+        expect(getDayName(DateTime.local(2022, 3, 21), 'en')).to.eq('MONDAY')
+        expect(getDayName(DateTime.local(2022, 3, 22), 'en')).to.eq('TUESDAY')
+        expect(getDayName(DateTime.local(2022, 3, 23), 'en')).to.eq('WEDNESDAY')
+        expect(getDayName(DateTime.local(2022, 3, 24), 'en')).to.eq('THURSDAY')
+        expect(getDayName(DateTime.local(2022, 3, 25), 'en')).to.eq('FRIDAY')
+        expect(getDayName(DateTime.local(2022, 3, 26), 'en')).to.eq('SATURDAY')
+      })
     })
   })
 })

--- a/test/lib/utils_test.js
+++ b/test/lib/utils_test.js
@@ -34,7 +34,7 @@ describe('/lib/utils', () => {
     })
   })
 
-  describe.only('.getDayName', () => {
+  describe('.getDayName', () => {
     it('returns an uppercase string', () => {
       const dateTime = DateTime.local()
       const subject = getDayName(dateTime)

--- a/test/lib/utils_test.js
+++ b/test/lib/utils_test.js
@@ -1,5 +1,7 @@
+const { DateTime } = require('luxon')
 const { expect } = require('chai')
-const { isAllowedStreamYardUser, preventUrlExpansion } = require('../../lib/utils')
+
+const { isAllowedStreamYardUser, preventUrlExpansion, getDayName } = require('../../lib/utils')
 
 describe('/lib/utils', () => {
   describe('.isAllowedStreamYardUser', () => {
@@ -29,6 +31,24 @@ describe('/lib/utils', () => {
         'one urt at <http://example.com/foobar>',
         'and other at <http://codeminer42.com.br?somequery=dont%20panic>'
       ].join('\n'))
+    })
+  })
+
+  describe('.getDayName', () => {
+    it('returns an uppercase string', () => {
+      const dateTime = DateTime.local()
+      const subject = getDayName(dateTime)
+      expect(subject).to.eq(subject.toUpperCase())
+    })
+
+    it('returns the name of each day of the week', () => {
+      expect(getDayName(DateTime.local(2022, 3, 20))).to.eq('DOMINGO')
+      expect(getDayName(DateTime.local(2022, 3, 21))).to.eq('SEGUNDA-FEIRA')
+      expect(getDayName(DateTime.local(2022, 3, 22))).to.eq('TERÇA-FEIRA')
+      expect(getDayName(DateTime.local(2022, 3, 23))).to.eq('QUARTA-FEIRA')
+      expect(getDayName(DateTime.local(2022, 3, 24))).to.eq('QUINTA-FEIRA')
+      expect(getDayName(DateTime.local(2022, 3, 25))).to.eq('SEXTA-FEIRA')
+      expect(getDayName(DateTime.local(2022, 3, 26))).to.eq('SÁBADO')
     })
   })
 })

--- a/test/scripts/google_test.js
+++ b/test/scripts/google_test.js
@@ -183,13 +183,16 @@ describe('google', () => {
 
     const message = [
       '',
+      '> QUINTA-FEIRA',
       '> **chuva agora**',
       '> _28 de jan. de 2077 14:59_',
       '> <http://example.com/chuva>',
       '',
+      '> SEXTA-FEIRA',
       '> **iih hoje é dia de beber mas so depois do trabalho**',
       '> _29 de jan. de 2077 17:00_',
       '',
+      '> SÁBADO',
       '> **encerrando o expediente com uma opera**',
       '> _30 de jan. de 2077 17:00_'
     ].join('\n')


### PR DESCRIPTION
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

#### What does this PR do?

This PR updates the `getCalendarEvents` function used to retrieve data from marvin's Google Calendar.
It moves the verification of dates in `retrieveCalendar.js` to be a parameter in on the request calls.
It also fixes the date exhibition. Previously, when requesting from Google API, it would show the date of creation of the events instead of the date of ocurrence. Courtesy of @paulodiovani :

```
marvin> !calendar
marvin> 
> **Workshop: #opensource**
> _17 de set. de 2021 09:30_

> **Workshop: DevOps**
> _29 de set. de 2021 17:30_

> **Workshop: Modern-Java by Philipe e Martin**
> _6 de out. de 2021 17:00_

> **Grupo de estudos de frontend**
> _9 de nov. de 2021 16:30_

> **Grupo de estudos de Elixir**
> _27 de jan. de 2022 17:00_

> **Grupo de estudos Ruby by Sam, Paty e Boniatti**
> _28 de mar. de 2022 17:00_
```

Also, there's a small update on the response. Instead of bringing every event on the current week, It'll bring events between the current day and the end of the current week. 

#### Where should the reviewer start?

The reviewer can start by seeing the changes on `calendarEvents.js` and the respective API call change.

**NOTE:** I'm opening this PR on a Friday, so there are no upcoming events. But you can hard-code a period to fetch data on `calendarEvents.js`:

```js
// Current implementation
13  const currentDay = DateTime.local().setZone('America/Sao_Paulo').toISO()
14  const endOfTheCurrentWeek = DateTime.local().setZone('America/Sao_Paulo').endOf('week').toISO()

// Update .local() to define the period. This one is from Sunday to Saturday
13  const currentDay = DateTime.local(2022, 3, 27).setZone('America/Sao_Paulo').toISO()
14  const endOfTheCurrentWeek = DateTime.local(2022, 4, 2).setZone('America/Sao_Paulo').endOf('week').toISO()
``` 

Just run `!calendar` to see the changes

#### What testing has been done on this PR?

I've experimented a lot with the dates and events, trying to bring data from different periods. However, no new tests cases were added.

#### What are the relevant issues?

Currently when we run the `!calendar` command, we get an error.

#### Screenshots (if appropriate)

![marinv1](https://user-images.githubusercontent.com/50644753/161328326-26a01a14-ae8f-4e22-88f5-268adb7b2cfb.png)
![marvin2](https://user-images.githubusercontent.com/50644753/161309597-578cce45-bc07-4b33-b242-f422f958ecdd.png)

#### Is this change backwards compatible or is it a breaking change?

It's backwards compatible. Though it won't bring the same result, depending on the day you're running.

### Observations

I took the liberty to include the "Workshops & Grupos de estudo" calendar on Marvin's Google account.
It wasn't showing anything regarding that when you logged in, though it's on the same organization. Did this because it was one of my attempts to solve this issue.
I apologize if this wasn't required.
