### PR TITLE
feat: Add `!brownbagfree` command

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,10 @@
+const { DateTime } = require('luxon')
+
 const URL_RE = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/g
 const INTERVAL_BETWEEN_STREAMS_IN_DAYS = 7
+const STREAM_WEEK_DAY = 4
+const STREAM_TIME_HOUR = 12
+const STREAM_TIME_MINUTES = 30
 
 const isAllowedStreamYardUser = (userId) => {
   const allowedUsers = process.env.ALLOWED_STREAMYARD_USERS ? process.env.ALLOWED_STREAMYARD_USERS.split(',') : []
@@ -14,6 +19,10 @@ const getDayName = (dateTime, locale = 'pt-br') => {
 }
 
 const getNextStreamDateAvailable = (streamDates) => {
+  if (streamDates.length === 0) {
+    return getClosestStreamDate(DateTime.now())
+  }
+
   const lastStreamDate = streamDates[streamDates.length - 1]
 
   for (let i = 0; i < streamDates.length - 1; i++) {
@@ -28,6 +37,13 @@ const getNextStreamDateAvailable = (streamDates) => {
   }
 
   return lastStreamDate.plus({ days: INTERVAL_BETWEEN_STREAMS_IN_DAYS })
+}
+
+const getClosestStreamDate = date => {
+  if (date.weekday !== STREAM_WEEK_DAY) {
+    return getClosestStreamDate(date.plus({ days: 1 }))
+  }
+  return date.set({ hours: STREAM_TIME_HOUR, minutes: STREAM_TIME_MINUTES })
 }
 
 module.exports = { isAllowedStreamYardUser, preventUrlExpansion, getDayName, getNextStreamDateAvailable }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,5 @@
 const URL_RE = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/g
-const INTERVAL_BETWEEN_STREAMS = 7
+const INTERVAL_BETWEEN_STREAMS_IN_DAYS = 7
 
 const isAllowedStreamYardUser = (userId) => {
   const allowedUsers = process.env.ALLOWED_STREAMYARD_USERS ? process.env.ALLOWED_STREAMYARD_USERS.split(',') : []
@@ -26,12 +26,12 @@ const getNextStreamDateAvailable = (streamDates) => {
     const nextDate = streamDates[i + 1]
     const dateInterval = nextDate.diff(currentDate, 'days').toObject().days
 
-    if (dateInterval > INTERVAL_BETWEEN_STREAMS) {
-      return currentDate.plus({ days: INTERVAL_BETWEEN_STREAMS })
+    if (dateInterval > INTERVAL_BETWEEN_STREAMS_IN_DAYS) {
+      return currentDate.plus({ days: INTERVAL_BETWEEN_STREAMS_IN_DAYS })
     }
   }
 
-  return lastStreamDate.plus({ days: INTERVAL_BETWEEN_STREAMS })
+  return lastStreamDate.plus({ days: INTERVAL_BETWEEN_STREAMS_IN_DAYS })
 }
 
 module.exports = { isAllowedStreamYardUser, preventUrlExpansion, getDayName, getNextStreamDateAvailable }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,5 @@
 const URL_RE = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/g
+const INTERVAL_BETWEEN_STREAMS = 7
 
 const isAllowedStreamYardUser = (userId) => {
   const allowedUsers = process.env.ALLOWED_STREAMYARD_USERS ? process.env.ALLOWED_STREAMYARD_USERS.split(',') : []
@@ -12,4 +13,25 @@ const getDayName = (dateTime, locale = 'pt-br') => {
   return date.toLocaleDateString(locale, { weekday: 'long' }).toUpperCase()
 }
 
-module.exports = { isAllowedStreamYardUser, preventUrlExpansion, getDayName }
+const getNextStreamDateAvailable = (streamDates) => {
+  const lastStreamDate = streamDates[streamDates.length - 1]
+
+  for (let i = 0; i < streamDates.length - 1; i++) {
+    const currentDate = streamDates[i]
+
+    if (currentDate.equals(lastStreamDate)) {
+      break
+    }
+
+    const nextDate = streamDates[i + 1]
+    const dateInterval = nextDate.diff(currentDate, 'days').toObject().days
+
+    if (dateInterval > INTERVAL_BETWEEN_STREAMS) {
+      return currentDate.plus({ days: INTERVAL_BETWEEN_STREAMS })
+    }
+  }
+
+  return lastStreamDate.plus({ days: INTERVAL_BETWEEN_STREAMS })
+}
+
+module.exports = { isAllowedStreamYardUser, preventUrlExpansion, getDayName, getNextStreamDateAvailable }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,12 +18,8 @@ const getNextStreamDateAvailable = (streamDates) => {
 
   for (let i = 0; i < streamDates.length - 1; i++) {
     const currentDate = streamDates[i]
-
-    if (currentDate.equals(lastStreamDate)) {
-      break
-    }
-
     const nextDate = streamDates[i + 1]
+
     const dateInterval = nextDate.diff(currentDate, 'days').toObject().days
 
     if (dateInterval > INTERVAL_BETWEEN_STREAMS_IN_DAYS) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,8 +3,10 @@ const { DateTime } = require('luxon')
 const URL_RE = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/g
 const INTERVAL_BETWEEN_STREAMS_IN_DAYS = 7
 const STREAM_WEEK_DAY = 4
-const STREAM_TIME_HOUR = 12
-const STREAM_TIME_MINUTES = 30
+const STREAM_TIME = {
+  hours: 12,
+  minutes: 30
+}
 
 const isAllowedStreamYardUser = (userId) => {
   const allowedUsers = process.env.ALLOWED_STREAMYARD_USERS ? process.env.ALLOWED_STREAMYARD_USERS.split(',') : []
@@ -43,7 +45,7 @@ const getClosestStreamDate = date => {
   if (date.weekday !== STREAM_WEEK_DAY) {
     return getClosestStreamDate(date.plus({ days: 1 }))
   }
-  return date.set({ hours: STREAM_TIME_HOUR, minutes: STREAM_TIME_MINUTES })
+  return date.set(STREAM_TIME)
 }
 
 module.exports = { isAllowedStreamYardUser, preventUrlExpansion, getDayName, getNextStreamDateAvailable }

--- a/scripts/customCommand.js
+++ b/scripts/customCommand.js
@@ -10,6 +10,7 @@ const preDefinedCommands = [
   'brownbag',
   'brownbagnext',
   'brownbagprev',
+  'brownbagfree',
   'calendar',
   'egghead',
   'excuses',

--- a/scripts/google.js
+++ b/scripts/google.js
@@ -194,8 +194,9 @@ module.exports = (robot) => {
   robot.hear(/!brownbagfree\b/, res => {
     youtube
       .getStreams({ max: 10, status: 'upcoming' })
-      .then(streams => streams.map(stream => stream.snippet.scheduledStartTime))
-      .then(streamsDates => getNextStreamDateAvailable(streamsDates))
+      .then(streams => streams.map(stream => new Date(stream.snippet.scheduledStartTime)))
+      .then(streams => streams.map(stream => DateTime.fromJSDate(stream)))
+      .then(streams => getNextStreamDateAvailable(streams))
       .then(streamDate => [
         'We have a free brownbag slot for:',
         streamDate.toLocaleString(DateTime.DATETIME_MED)

--- a/scripts/google.js
+++ b/scripts/google.js
@@ -190,4 +190,21 @@ module.exports = (robot) => {
       .then(streams => res.send(streams))
       .catch(error => res.send(error.message))
   })
+
+  robot.hear(/!brownbagfree\b/, res => {
+    // TODO: tries to search between the period of the current date and the latest stream date
+    youtube
+      .getStreams({ max: 10, status: 'upcoming' })
+      .then(streams => streams.map(stream => stream.snippet.scheduledStartTime).reverse())
+      .then(dates => {
+        const lastScheduledDate = DateTime.fromISO(dates[0])
+        return lastScheduledDate.plus({ week: 1 })
+      })
+      .then(date => [
+        'We have a free brownbag slot for:',
+        date.toLocaleString(DateTime.DATE_SHORT)
+      ].join('\n'))
+      .then(date => res.send(date))
+      .catch(error => res.send(error.message))
+  })
 }

--- a/test/lib/utils_test.js
+++ b/test/lib/utils_test.js
@@ -1,7 +1,7 @@
 const { DateTime } = require('luxon')
 const { expect } = require('chai')
 
-const { isAllowedStreamYardUser, preventUrlExpansion, getDayName } = require('../../lib/utils')
+const { isAllowedStreamYardUser, preventUrlExpansion, getDayName, getNextStreamDateAvailable } = require('../../lib/utils')
 
 describe('/lib/utils', () => {
   describe('.isAllowedStreamYardUser', () => {
@@ -60,6 +60,50 @@ describe('/lib/utils', () => {
         expect(getDayName(DateTime.local(2022, 3, 24), 'en')).to.eq('THURSDAY')
         expect(getDayName(DateTime.local(2022, 3, 25), 'en')).to.eq('FRIDAY')
         expect(getDayName(DateTime.local(2022, 3, 26), 'en')).to.eq('SATURDAY')
+      })
+    })
+  })
+
+  describe('.getNextStreamDateAvailable', () => {
+    describe('when there are no available date before the last upcoming stream', () => {
+      it('returns the last date + 7 days', () => {
+        const dates = [
+          DateTime.utc(2022, 6, 2),
+          DateTime.utc(2022, 6, 9),
+          DateTime.utc(2022, 6, 16),
+          DateTime.utc(2022, 6, 23)
+        ]
+
+        const expectedDate = DateTime.utc(2022, 6, 30)
+
+        expect(getNextStreamDateAvailable(dates)).to.eql(expectedDate)
+      })
+    })
+
+    describe('when there is a single available dates before the last upcoming stream', () => {
+      it('returns the first available date in the gap', () => {
+        const dates = [
+          DateTime.utc(2022, 6, 2),
+          DateTime.utc(2022, 6, 16),
+          DateTime.utc(2022, 6, 23)
+        ]
+
+        const expectedDate = DateTime.utc(2022, 6, 9)
+
+        expect(getNextStreamDateAvailable(dates)).to.eql(expectedDate)
+      })
+    })
+
+    describe('when there are N available dates before the last upcoming stream', () => {
+      it('returns the first available date in the gap', () => {
+        const dates = [
+          DateTime.utc(2022, 6, 2),
+          DateTime.utc(2022, 6, 23)
+        ]
+
+        const expectedDate = DateTime.utc(2022, 6, 9)
+
+        expect(getNextStreamDateAvailable(dates)).to.eql(expectedDate)
       })
     })
   })

--- a/test/lib/utils_test.js
+++ b/test/lib/utils_test.js
@@ -65,6 +65,17 @@ describe('/lib/utils', () => {
   })
 
   describe('.getNextStreamDateAvailable', () => {
+    describe('when there are no upcoming streams', () => {
+      it('returns the next Thursday date', () => {
+        const dates = []
+
+        const expectedWeekDay = 4
+        const actualWeekDay = getNextStreamDateAvailable(dates).weekday
+
+        expect(expectedWeekDay).to.eql(actualWeekDay)
+      })
+    })
+
     describe('when there are no available date before the last upcoming stream', () => {
       it('returns the last date + 7 days', () => {
         const dates = [
@@ -80,7 +91,7 @@ describe('/lib/utils', () => {
       })
     })
 
-    describe('when there is a single available dates before the last upcoming stream', () => {
+    describe('when there is a single available date before the last upcoming stream', () => {
       it('returns the first available date in the gap', () => {
         const dates = [
           DateTime.utc(2022, 6, 2),


### PR DESCRIPTION
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

#### What does this PR do?

This PR adds a new command - `!brownbagfree` - that returns the date of the closest free slot of a brownbag.

#### Where should the reviewer start?

`scripts/google.js`

#### What testing has been done on this PR?

None. Still a WIP.

#### What are the relevant issues?

None

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/50644753/174079635-96b39b9f-8e72-435e-97d9-60467465ceac.png)

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible

#### Important observations:

As it is still a WIP, it'll always bring the free slot after the latest stream.
I also want to implement a verification that iterates over the `dates` array, and also verify if we have a free slot there.