### PR TITLE
fix: gitlab learning resources URL

### DIFF
--- a/lib/google/retrieveEmail.js
+++ b/lib/google/retrieveEmail.js
@@ -47,7 +47,7 @@ const getEggHeadEmail = async () => {
   if (message === null) {
     return `**There are no unread Egghead emails!**
     \n⚠️ Please, try to log in again, and check in a minute.
-    \n📒 Follow the instructions: https://gitlab42.com/Codeminer42/Codeminer-42/wikis/learning-resources
+    \n📒 Follow the instructions: https://gitlab.com/codeminer-42/codeminer42/-/wikis/learning-resources
     \n🔗 Sign In: https://egghead.io/login`
   }
 


### PR DESCRIPTION
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

#### What does this PR do?
Fix the URL for learning resources. 

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### What are the relevant issues?
When send !egghead to Marvin it prints the worng link to learning resources on codeminer42 gitlab.

#### Screenshots (if appropriate)
<img width="720" alt="image" src="https://user-images.githubusercontent.com/7703431/193869521-bd636a2b-d5a5-4672-9d29-ae75a4cc682b.png">

#### Is this change backwards compatible or is it a breaking change?
backwards compatible 